### PR TITLE
Added es6 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/kasunkv/protractor-starter#readme",
   "dependencies": {
+    "es6-promise": "^4.0.5",
     "jasmine": "^2.5.2",
     "jasmine-reporters": "^2.2.0",
     "protractor": "^4.0.9",


### PR DESCRIPTION
I was getting an error 
`helpers/waitHelper.ts(3,25): error TS2307: Cannot find module 'es6-promise'.`

I added `es6-promise` to the `package.json` 

`$ npm install es6-promise --save`

Please let me know if you have any questions! 
![screen shot 2016-10-25 at 1 30 58 am](https://cloud.githubusercontent.com/assets/17118009/19674005/e75e4ae0-9a52-11e6-9f5b-49b6ba355fb5.png)
